### PR TITLE
Fixed deprecation warning regarding 'gems' configuration in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Plugins
-gems:
+plugins:
 - jekyll-redirect-from
 - jekyll-paginate
 safe: false


### PR DESCRIPTION
Based on issue #21 
Fixed deprecation warning by replacing 'gems' to 'plugins'